### PR TITLE
Fix integration with sunfish 2016

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,0 +1,79 @@
+import numpy
+import theano
+import theano.tensor as T
+rng = numpy.random
+
+def get_parameters(n_in=None, n_hidden_units=2048, n_hidden_layers=None, Ws=None, bs=None):
+    if Ws is None or bs is None:
+        print 'initializing Ws & bs'
+        if type(n_hidden_units) != list:
+            n_hidden_units = [n_hidden_units] * n_hidden_layers
+        else:
+            n_hidden_layers = len(n_hidden_units)
+
+        Ws = []
+        bs = []
+
+        def W_values(n_in, n_out):
+            return numpy.asarray(rng.uniform(
+                low=-numpy.sqrt(6. / (n_in + n_out)),
+                high=numpy.sqrt(6. / (n_in + n_out)),
+                size=(n_in, n_out)), dtype=theano.config.floatX)
+
+        
+        for l in xrange(n_hidden_layers):
+            if l == 0:
+                n_in_2 = n_in
+            else:
+                n_in_2 = n_hidden_units[l-1]
+            if l < n_hidden_layers - 1:
+                n_out_2 = n_hidden_units[l]
+                W = W_values(n_in_2, n_out_2)
+                gamma = 0.1 # initialize it to slightly positive so the derivative exists
+                b = numpy.ones(n_out_2, dtype=theano.config.floatX) * gamma
+            else:
+                W = numpy.zeros(n_in_2, dtype=theano.config.floatX)
+                b = floatX(0.)
+            Ws.append(W)
+            bs.append(b)
+
+    Ws_s = [theano.shared(W) for W in Ws]
+    bs_s = [theano.shared(b) for b in bs]
+
+    return Ws_s, bs_s
+
+
+def get_model(Ws_s, bs_s, dropout=False):
+    print 'building expression graph'
+    x_s = T.matrix('x')
+
+    if type(dropout) != list:
+        dropout = [dropout] * len(Ws_s)
+
+    # Convert input into a 12 * 64 list
+    pieces = []
+    for piece in [1,2,3,4,5,6, 8,9,10,11,12,13]:
+        # pieces.append((x_s <= piece and x_s >= piece).astype(theano.config.floatX))
+        pieces.append(T.eq(x_s, piece))
+
+    binary_layer = T.concatenate(pieces, axis=1)
+
+    srng = theano.tensor.shared_randomstreams.RandomStreams(
+        rng.randint(999999))
+
+    last_layer = binary_layer
+    n = len(Ws_s)
+    for l in xrange(n - 1):
+        # h = T.tanh(T.dot(last_layer, Ws[l]) + bs[l])
+        h = T.dot(last_layer, Ws_s[l]) + bs_s[l]
+        h = h * (h > 0)
+        
+        if dropout[l]:
+            mask = srng.binomial(n=1, p=0.5, size=h.shape)
+            h = h * T.cast(mask, theano.config.floatX) * 2
+
+        last_layer = h
+
+    p_s = T.dot(last_layer, Ws_s[-1]) + bs_s[-1]
+    return x_s, p_s
+

--- a/play.py
+++ b/play.py
@@ -177,9 +177,10 @@ class Human(Player):
 
 
 class Sunfish(Player):
-    def __init__(self, maxn=1e4):
+    def __init__(self, secs=1):
+        self._searcher = sunfish.Searcher()
         self._pos = sunfish.Position(sunfish.initial, 0, (True,True), (True,True), 0, 0)
-        self._maxn = maxn
+        self._secs = secs
 
     def move(self, gn_current):
         import sunfish
@@ -192,7 +193,7 @@ class Sunfish(Player):
         self._pos = self._pos.move(move)
 
         t0 = time.time()
-        move, score = sunfish.search(self._pos, maxn=self._maxn)
+        move, score = self._searcher.search(self._pos, self._secs)
         print time.time() - t0, move, score
         self._pos = self._pos.move(move)
 
@@ -209,12 +210,12 @@ def game(func):
     gn_current = chess.pgn.Game()
 
     maxd = random.randint(1, 2) # max depth for deep pink
-    maxn = 10 ** (2.0 + random.random() * 1.0) # max nodes for sunfish
+    secs = random.random() # max seconds for sunfish
 
-    print 'maxd %f maxn %f' % (maxd, maxn)
+    print 'maxd %f secs %f' % (maxd, secs)
 
     player_a = Computer(func, maxd=maxd)
-    player_b = Sunfish(maxn=maxn)
+    player_b = Sunfish(secs=secs)
 
     times = {'A': 0.0, 'B': 0.0}
     

--- a/play.py
+++ b/play.py
@@ -1,10 +1,9 @@
-import train
+import load
 import pickle
 import theano
 import theano.tensor as T
 import math
 import chess, chess.pgn
-from parse_game import bb2array
 import heapq
 import time
 import re
@@ -20,8 +19,8 @@ def get_model_from_pickle(fn):
     f = open(fn)
     Ws, bs = pickle.load(f)
     
-    Ws_s, bs_s = train.get_parameters(Ws=Ws, bs=bs)
-    x, p = train.get_model(Ws_s, bs_s)
+    Ws_s, bs_s = load.get_parameters(Ws=Ws, bs=bs)
+    x, p = load.get_model(Ws_s, bs_s)
     
     predict = theano.function(
         inputs=[x],

--- a/reinforcement.py
+++ b/reinforcement.py
@@ -1,4 +1,5 @@
 import train
+import load
 import theano
 import theano.tensor as T
 # import chess, chess.pgn
@@ -31,7 +32,7 @@ def get_params(fns):
 
 
 def get_predict(Ws_s, bs_s):
-    x, p = train.get_model(Ws_s, bs_s)
+    x, p = load.get_model(Ws_s, bs_s)
     
     predict = theano.function(
         inputs=[x],
@@ -41,7 +42,7 @@ def get_predict(Ws_s, bs_s):
 
 
 def get_update(Ws_s, bs_s):
-    x, fx = train.get_model(Ws_s, bs_s)
+    x, fx = load.get_model(Ws_s, bs_s)
 
     # Ground truth (who won)
     y = T.vector('y')
@@ -127,7 +128,7 @@ def game(f_pred, f_train, learning_rate, momentum=0.9):
 
 def main():
     Ws, bs = get_params(['model_reinforcement.pickle', 'model.pickle'])
-    Ws_s, bs_s = train.get_parameters(Ws=Ws, bs=bs)
+    Ws_s, bs_s = load.get_parameters(Ws=Ws, bs=bs)
     f_pred = get_predict(Ws_s, bs_s)
     f_train = get_update(Ws_s, bs_s)
 

--- a/train.py
+++ b/train.py
@@ -1,3 +1,4 @@
+import load
 import numpy
 import theano
 import theano.tensor as T
@@ -13,8 +14,6 @@ import math
 import time
 
 MINIBATCH_SIZE = 2000
-
-rng = numpy.random
 
 def floatX(x):
     return numpy.asarray(x, dtype=theano.config.floatX)
@@ -57,88 +56,14 @@ def get_data(series=['x', 'xr']):
     return data
 
 
-def get_parameters(n_in=None, n_hidden_units=2048, n_hidden_layers=None, Ws=None, bs=None):
-    if Ws is None or bs is None:
-        print 'initializing Ws & bs'
-        if type(n_hidden_units) != list:
-            n_hidden_units = [n_hidden_units] * n_hidden_layers
-        else:
-            n_hidden_layers = len(n_hidden_units)
-
-        Ws = []
-        bs = []
-
-        def W_values(n_in, n_out):
-            return numpy.asarray(rng.uniform(
-                low=-numpy.sqrt(6. / (n_in + n_out)),
-                high=numpy.sqrt(6. / (n_in + n_out)),
-                size=(n_in, n_out)), dtype=theano.config.floatX)
-
-        
-        for l in xrange(n_hidden_layers):
-            if l == 0:
-                n_in_2 = n_in
-            else:
-                n_in_2 = n_hidden_units[l-1]
-            if l < n_hidden_layers - 1:
-                n_out_2 = n_hidden_units[l]
-                W = W_values(n_in_2, n_out_2)
-                gamma = 0.1 # initialize it to slightly positive so the derivative exists
-                b = numpy.ones(n_out_2, dtype=theano.config.floatX) * gamma
-            else:
-                W = numpy.zeros(n_in_2, dtype=theano.config.floatX)
-                b = floatX(0.)
-            Ws.append(W)
-            bs.append(b)
-
-    Ws_s = [theano.shared(W) for W in Ws]
-    bs_s = [theano.shared(b) for b in bs]
-
-    return Ws_s, bs_s
-
-
-def get_model(Ws_s, bs_s, dropout=False):
-    print 'building expression graph'
-    x_s = T.matrix('x')
-
-    if type(dropout) != list:
-        dropout = [dropout] * len(Ws_s)
-
-    # Convert input into a 12 * 64 list
-    pieces = []
-    for piece in [1,2,3,4,5,6, 8,9,10,11,12,13]:
-        # pieces.append((x_s <= piece and x_s >= piece).astype(theano.config.floatX))
-        pieces.append(T.eq(x_s, piece))
-
-    binary_layer = T.concatenate(pieces, axis=1)
-
-    srng = theano.tensor.shared_randomstreams.RandomStreams(
-        rng.randint(999999))
-
-    last_layer = binary_layer
-    n = len(Ws_s)
-    for l in xrange(n - 1):
-        # h = T.tanh(T.dot(last_layer, Ws[l]) + bs[l])
-        h = T.dot(last_layer, Ws_s[l]) + bs_s[l]
-        h = h * (h > 0)
-        
-        if dropout[l]:
-            mask = srng.binomial(n=1, p=0.5, size=h.shape)
-            h = h * T.cast(mask, theano.config.floatX) * 2
-
-        last_layer = h
-
-    p_s = T.dot(last_layer, Ws_s[-1]) + bs_s[-1]
-    return x_s, p_s
-
 
 def get_training_model(Ws_s, bs_s, dropout=False, lambd=10.0, kappa=1.0):
     # Build a dual network, one for the real move, one for a fake random move
     # Train on a negative log likelihood of classifying the right move
 
-    xc_s, xc_p = get_model(Ws_s, bs_s, dropout=dropout)
-    xr_s, xr_p = get_model(Ws_s, bs_s, dropout=dropout)
-    xp_s, xp_p = get_model(Ws_s, bs_s, dropout=dropout)
+    xc_s, xc_p = load.get_model(Ws_s, bs_s, dropout=dropout)
+    xr_s, xr_p = load.get_model(Ws_s, bs_s, dropout=dropout)
+    xp_s, xp_p = load.get_model(Ws_s, bs_s, dropout=dropout)
 
     #loss = -T.log(sigmoid(xc_p + xp_p)).mean() # negative log likelihood
     #loss += -T.log(sigmoid(-xp_p - xr_p)).mean() # negative log likelihood
@@ -204,7 +129,7 @@ def train():
 
     n_in = 12 * 64
 
-    Ws_s, bs_s = get_parameters(n_in=n_in, n_hidden_units=[2048] * 3)
+    Ws_s, bs_s = load.get_parameters(n_in=n_in, n_hidden_units=[2048] * 3)
     
     minibatch_size = min(MINIBATCH_SIZE, Xc_train.shape[0])
 


### PR DESCRIPTION
The newer versions of sunfish use seconds rather than max-nodes, which breaks the api deep-pink is using. This updates deep-pink to match the sunfish function signature.

The pull-request also moves some functions from train.py to a new module load.py. These are functions which are used by play.py, and don't require scikit-learn or h5py. Hence keeping them in train.py prevents playing deep-pink without these modules.